### PR TITLE
Fix auth modal positioning

### DIFF
--- a/frontend/src/components/SimpleModal.tsx
+++ b/frontend/src/components/SimpleModal.tsx
@@ -1,4 +1,5 @@
 import { useState, ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -441,7 +442,7 @@ export function SimpleModal({ children, defaultTab = 'login' }: SimpleModalProps
     );
   }
 
-  return (
+  const modalContent = (
     <div
       style={{
         position: 'fixed',
@@ -518,4 +519,6 @@ export function SimpleModal({ children, defaultTab = 'login' }: SimpleModalProps
       </div>
     </div>
   );
+
+  return createPortal(modalContent, document.body);
 }


### PR DESCRIPTION
## Summary
- render SimpleModal via React portal to ensure it centers correctly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ac6da37a48333a1ad2acc12bfc454