### PR TITLE
Fix login modal closing on failed auth

### DIFF
--- a/frontend/src/components/EnhancedAuthModal.tsx
+++ b/frontend/src/components/EnhancedAuthModal.tsx
@@ -84,8 +84,10 @@ export function EnhancedAuthModal({ children, defaultTab = 'login' }: EnhancedAu
   const handleLoginSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await login({ username: loginData.email, password: loginData.password });
-      handleClose();
+      const success = await login({ username: loginData.email, password: loginData.password });
+      if (success) {
+        handleClose();
+      }
     } catch (err) {
       console.error('Login error:', err);
     }

--- a/frontend/src/components/FixedAuthModal.tsx
+++ b/frontend/src/components/FixedAuthModal.tsx
@@ -99,8 +99,10 @@ export function FixedAuthModal({ children, defaultTab = 'login' }: FixedAuthModa
     e.preventDefault();
     console.log('Login submitted:', loginData);
     try {
-      await login({ username: loginData.email, password: loginData.password });
-      handleClose();
+      const success = await login({ username: loginData.email, password: loginData.password });
+      if (success) {
+        handleClose();
+      }
     } catch (err) {
       console.error('Login error:', err);
     }

--- a/frontend/src/components/RobustAuthModal.tsx
+++ b/frontend/src/components/RobustAuthModal.tsx
@@ -107,8 +107,10 @@ export function RobustAuthModal({ children, defaultTab = 'login' }: RobustAuthMo
     e.preventDefault();
     console.log('Login submitted:', loginData);
     try {
-      await login({ username: loginData.email, password: loginData.password });
-      handleClose();
+      const success = await login({ username: loginData.email, password: loginData.password });
+      if (success) {
+        handleClose();
+      }
     } catch (err) {
       console.error('Login error:', err);
     }

--- a/frontend/src/components/SimpleModal.tsx
+++ b/frontend/src/components/SimpleModal.tsx
@@ -74,8 +74,10 @@ export function SimpleModal({ children, defaultTab = 'login' }: SimpleModalProps
     e.preventDefault();
     console.log('SimpleModal: Login submitted:', loginData);
     try {
-      await login({ username: loginData.email, password: loginData.password });
-      handleClose();
+      const success = await login({ username: loginData.email, password: loginData.password });
+      if (success) {
+        handleClose();
+      }
     } catch (err) {
       console.error('SimpleModal: Login error:', err);
     }

--- a/frontend/src/components/UltimateAuthModal.tsx
+++ b/frontend/src/components/UltimateAuthModal.tsx
@@ -146,8 +146,10 @@ export function UltimateAuthModal({ children, defaultTab = 'login' }: UltimateAu
     e.preventDefault();
     console.log('Login submitted:', loginData);
     try {
-      await login({ username: loginData.email, password: loginData.password });
-      handleClose();
+      const success = await login({ username: loginData.email, password: loginData.password });
+      if (success) {
+        handleClose();
+      }
     } catch (err) {
       console.error('Login error:', err);
     }

--- a/frontend/src/components/WorkingAuthModal.tsx
+++ b/frontend/src/components/WorkingAuthModal.tsx
@@ -62,8 +62,10 @@ export function WorkingAuthModal({ children, defaultTab = 'login' }: WorkingAuth
     e.preventDefault();
     console.log('Login submitted:', loginData);
     try {
-      await login({ username: loginData.email, password: loginData.password });
-      handleClose();
+      const success = await login({ username: loginData.email, password: loginData.password });
+      if (success) {
+        handleClose();
+      }
     } catch (err) {
       console.error('Login error:', err);
     }


### PR DESCRIPTION
## Summary
- keep authentication modal open when login fails

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b8e9d1a9883338f427fedc2c4ee1d